### PR TITLE
Clear CGContext after finish drawing each side

### DIFF
--- a/Classes/JMMarkSlider.m
+++ b/Classes/JMMarkSlider.m
@@ -58,15 +58,6 @@
     CGContextStrokePath(context);
     UIImage *selectedSide = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero];
     
-    // Unselected side
-    CGContextSetLineCap(context, kCGLineCapRound);
-    CGContextSetLineWidth(context, 12.0);
-    CGContextMoveToPoint(context, 6, CGRectGetHeight(innerRect)/2);
-    CGContextAddLineToPoint(context, innerRect.size.width - 10, CGRectGetHeight(innerRect)/2);
-    CGContextSetStrokeColorWithColor(context, [self.unselectedBarColor CGColor]);
-    CGContextStrokePath(context);
-    UIImage *unselectedSide = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero];
-    
     // Set trips on selected side
     [selectedSide drawAtPoint:CGPointMake(0,0)];
     for (int i = 0; i < [self.markPositions count]; i++) {
@@ -78,6 +69,17 @@
         CGContextStrokePath(context);
     }
     UIImage *selectedStripSide = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero];
+    
+    CGContextClearRect(context, rect);
+    
+    // Unselected side
+    CGContextSetLineCap(context, kCGLineCapRound);
+    CGContextSetLineWidth(context, 12.0);
+    CGContextMoveToPoint(context, 6, CGRectGetHeight(innerRect)/2);
+    CGContextAddLineToPoint(context, innerRect.size.width - 10, CGRectGetHeight(innerRect)/2);
+    CGContextSetStrokeColorWithColor(context, [self.unselectedBarColor CGColor]);
+    CGContextStrokePath(context);
+    UIImage *unselectedSide = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero];
     
     // Set trips on unselected side
     [unselectedSide drawAtPoint:CGPointMake(0,0)];
@@ -91,6 +93,7 @@
     }
     UIImage *unselectedStripSide = [UIGraphicsGetImageFromCurrentImageContext() resizableImageWithCapInsets:UIEdgeInsetsZero];
     
+    CGContextClearRect(context, rect);
     UIGraphicsEndImageContext();
     
     [self setMinimumTrackImage:selectedStripSide forState:UIControlStateNormal];


### PR DESCRIPTION
Fix barSelected and barUnselected overlap eachother when set barcolor alpha less than 1 it show another bar. I rearrange draw order and clear CGContext.
